### PR TITLE
Fix early SIGSEGV on x86

### DIFF
--- a/hotspot/src/os/linux/vm/os_linux.cpp
+++ b/hotspot/src/os/linux/vm/os_linux.cpp
@@ -2477,8 +2477,7 @@ void os::jvm_path(char *buf, jint buflen) {
                 dli_fname, sizeof(dli_fname), NULL);
   assert(ret, "cannot locate libjvm");
 #ifdef __ANDROID__
-  char* java_home_var = ::getenv("JAVA_HOME");
-  if (java_home_var == NULL || dli_fname[0] == '\0') {
+  if (dli_fname[0] == '\0') {
     return;
   }
 


### PR DESCRIPTION
This PR fixes a segmentation fault when libjvm.so could not be located on x86 systems.
The rest of the JVM seems to work, however, due to android limitations the allowed memory allocations is very small, so only old versions may run.